### PR TITLE
make links prettier on the client side

### DIFF
--- a/build/handbook.html
+++ b/build/handbook.html
@@ -9,6 +9,7 @@
   <link rel="shortcut icon" type="image/x-icon" href="./assets/images/logo.svg" />
   <script src="scripts/navbar.js" defer></script>
   <script src="scripts/navbar-hide-scroll.js" defer></script>
+  <script src="scripts/fix-links.js" defer></script>
   <!--<script src="scripts/background-canvas.js" defer></script><-->
 
   <title>XHacks '26 | Handbook</title>

--- a/build/index.html
+++ b/build/index.html
@@ -11,6 +11,7 @@
   <script src="scripts/navbar-hide-scroll.js" defer></script>
   <script src="scripts/faqs.js" defer></script>
   <script src="scripts/team.js" defer></script>
+  <script src="scripts/fix-links.js" defer></script>
 
   <title>XHacks '26 | Main</title>
   <meta name="description"

--- a/build/scripts/fix-links.js
+++ b/build/scripts/fix-links.js
@@ -1,0 +1,33 @@
+// fixes up links so that they work with Live Preview locally
+// but also generate nicer URLs in production
+
+const linkMappings = {
+    'index.html': '/',
+    './index.html': '/',
+    'handbook.html': '/handbook'
+};
+
+function fixLinks() {
+    // Only apply fixes if in production
+    const isLocalhost = window.location.hostname === 'localhost' || 
+                       window.location.hostname === '127.0.0.1';
+    
+    if (isLocalhost) {
+        return;
+    }
+    
+    // Fix all links in the document
+    Object.entries(linkMappings).forEach(([file, newPath]) => {
+        const links = document.querySelectorAll(`a[href="${file}"]`);
+        links.forEach(link => {
+            link.href = newPath;
+        });
+    });
+}
+
+// Run when DOM is ready
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', fixLinks);
+} else {
+    fixLinks();
+}


### PR DESCRIPTION
problem:
- we have long links right now that aren't neccessary 
  - ie `https://systemshacks.com/handbook.html` and `https://systemshacks.com/index.html` (when navigating back from the handbook page)

this solution fixes this on the client side without changing anything about the development process

the alternative is to do this in the build step on github actions but that is flakier than this

downsides
- one more js file to maintain
- doesn't work if js is disabled